### PR TITLE
fix/database-limitations

### DIFF
--- a/src/services/__tests__/db.test.ts
+++ b/src/services/__tests__/db.test.ts
@@ -4,7 +4,7 @@ import { client } from '../../db';
 import { getAllSymbols, getDailySeries, populateDb } from '../db';
 import { dailySeriesData, dailySeriesLatestData, mockAvEndpoint, symbolData } from './util/alpha-vantage-mock';
 import * as dailySeriesLatest from './util/data/daily-series-latest.json';
-import * as dailySeries from './util/data/daily-series.json';
+import * as dailySeriesWithPreHistory from './util/data/daily-series-with-pre-history.json';
 import * as symbolSearch from './util/data/symbol-search.json';
 
 import 'jest';
@@ -34,7 +34,7 @@ describe('Database', async () => {
         outputsize: 'full',
       },
       200,
-      dailySeries
+      dailySeriesWithPreHistory
     );
 
     await populateDb(['AAPL']);

--- a/src/services/__tests__/util/data/daily-series-with-pre-history.json
+++ b/src/services/__tests__/util/data/daily-series-with-pre-history.json
@@ -1,0 +1,39 @@
+{
+  "Meta Data": {
+    "1. Information": "Daily Prices (open, high, low, close) and Volumes",
+    "2. Symbol": "AAPL",
+    "3. Last Refreshed": "2018-11-09",
+    "4. Output Size": "Compact",
+    "5. Time Zone": "US/Eastern"
+  },
+  "Time Series (Daily)": {
+    "2018-11-07": {
+      "1. open": "205.9700",
+      "2. high": "210.0600",
+      "3. low": "204.1300",
+      "4. close": "209.9500",
+      "5. volume": "33424434"
+    },
+    "2018-11-06": {
+      "1. open": "201.9200",
+      "2. high": "204.7200",
+      "3. low": "201.6900",
+      "4. close": "203.7700",
+      "5. volume": "31882881"
+    },
+    "2017-12-31": {
+      "1. open": "151.9200",
+      "2. high": "154.7200",
+      "3. low": "151.6900",
+      "4. close": "153.7700",
+      "5. volume": "31382881"
+    },
+    "2017-12-30": {
+      "1. open": "251.9200",
+      "2. high": "254.7200",
+      "3. low": "251.6900",
+      "4. close": "253.7700",
+      "5. volume": "31884681"
+    }
+  }
+}

--- a/src/services/stock-data-types.ts
+++ b/src/services/stock-data-types.ts
@@ -1,5 +1,12 @@
-type SymbolName = 'AAPL'; // AMZN | 'BABA' | 'BAC' | 'DIS' | 'GOOGL';
-const SUPPORTED_SYMBOLS: SymbolName[] = ['AAPL']; //, 'AMZN', 'BABA', 'BAC', 'DIS', 'GOOGL'];
+type SymbolName = 'AAPL' | 'AMZN' | 'BABA' | 'BAC' | 'DIS' | 'GOOGL';
+const SUPPORTED_SYMBOLS: SymbolName[] = [
+  'AAPL',
+  'AMZN',
+  'BABA',
+  'BAC',
+  'DIS',
+  'GOOGL',
+];
 
 interface Stock {
   symbol: string;


### PR DESCRIPTION
This PR fixes the problem with Heroku Postgres free tier limitations (10 000 rows) by restricting the stock quotes history length.

- Restrict stock quote history to the beginning of 2018
- Add test for testing the restriction
- Fix a bug when db could not be updated because of time zone issues.

Can be tested with, e.g., [`/stock/GOOGL/history`](http://sijoitussimu-stock-stagin-pr-5.herokuapp.com/stock/GOOGL/history) and [`/stock/AMZN/history`](http://sijoitussimu-stock-stagin-pr-5.herokuapp.com/stock/AMZN/history).

<img width="195" alt="nayttokuva 2018-12-19 kello 22 35 10" src="https://user-images.githubusercontent.com/9673395/50246569-6e51fa00-03de-11e9-83a2-a3db54a39711.png">
